### PR TITLE
Upgrading IntelliJ from 2023.3.5 to 2023.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2023.3.5 to 2023.3.6
 - Upgrading IntelliJ from 2023.3.4 to 2023.3.5
 
 ### Deprecated

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libraryGroup = com.chriscarini.jetbrains
 # SemVer format -> https://semver.org
-libraryVersion = 0.0.3
+libraryVersion = 0.0.4
 
 ##
 # ----- JETBRAINS PLATFORM PLUGIN SETTINGS -----
@@ -13,7 +13,7 @@ libraryVersion = 0.0.3
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2023.3.5
+platformVersion = 2023.3.6
 platformDownloadSources = true
 
 # Java language level used to compile sources and to generate the files for


### PR DESCRIPTION

# Upgrading IntelliJ from 2023.3.5 to 2023.3.6

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661893/IntelliJ-IDEA-2023.3.6-233.15026.9-build-Release-Notes

# What's New?
IntelliJ IDEA 2023.3.6 is out. This latest version brings an important fix for macOS users: 
<ul> 
 <li>We've introduced a workaround to reduce the probability of IDE crashes after updating to macOS Sonoma 14.4. [<a href="https://youtrack.jetbrains.com/issue/JBR-6802">JBR-6802</a>]</li> 
</ul> For more details, refer to our 
<a href="https://blog.jetbrains.com/idea/2024/03/intellij-idea-2023-3-6/">blog post</a>.
    