### PR TITLE
Upgrading IntelliJ from 2024.1 to 2024.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.1 to 2024.1.1
 - Upgrading IntelliJ from 2023.3.6 to 2024.1.0
 - Upgrading IntelliJ from 2023.3.5 to 2023.3.6
 - Upgrading IntelliJ from 2023.3.4 to 2023.3.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libraryGroup = com.chriscarini.jetbrains
 # SemVer format -> https://semver.org
-libraryVersion = 0.0.5
+libraryVersion = 0.0.6
 
 ##
 # ----- JETBRAINS PLATFORM PLUGIN SETTINGS -----
@@ -13,7 +13,7 @@ libraryVersion = 0.0.5
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2024.1
+platformVersion = 2024.1.1
 platformDownloadSources = true
 
 # Java language level used to compile sources and to generate the files for


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.1 to 2024.1.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661951/IntelliJ-IDEA-2024.1.1-241.15989.150-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.1.1 is out with the following updates: 
<ul> 
 <li>AI Assistant is now available in IntelliJ IDEA Community Edition.</li> 
 <li>Code validation no longer produces incorrect code highlighting caused by freezes while reevaluating inspections. [<a href="https://youtrack.jetbrains.com/issue/IJPL-28967">IJPL-28967</a>]</li> 
 <li>Gradle project builds no longer fail during testing when the JaCoCo plugin is used. [<a href="https://youtrack.jetbrains.com/issue/IDEA-344011">IDEA-344011</a>]</li> 
 <li>We fixed the issue that caused failures when opening Gradle projects on WSL due to a missing JDK. [<a href="https://youtrack.jetbrains.com/issue/IDEA-329792">IDEA-329792</a>]</li> 
</ul> Get more details in our 
<a href="https://blog.jetbrains.com/idea/2024/04/intellij-idea-2024-1-1/">blog post</a>.
    