### PR TITLE
Upgrading IntelliJ from 2024.1.1 to 2024.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.1 to 2024.1.2
 - Upgrading IntelliJ from 2023.3.6 to 2024.1.0
 - Upgrading IntelliJ from 2023.3.5 to 2023.3.6
 - Upgrading IntelliJ from 2023.3.4 to 2023.3.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libraryGroup = com.chriscarini.jetbrains
 # SemVer format -> https://semver.org
-libraryVersion = 0.0.5
+libraryVersion = 0.0.6
 
 ##
 # ----- JETBRAINS PLATFORM PLUGIN SETTINGS -----
@@ -13,7 +13,7 @@ libraryVersion = 0.0.5
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2024.1
+platformVersion = 2024.1.2
 platformDownloadSources = true
 
 # Java language level used to compile sources and to generate the files for


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.1.1 to 2024.1.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661977/IntelliJ-IDEA-2024.1.2-241.17011.79-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.1.2 is out with the following updates: 
<ul> 
 <li>The IDE no longer crashes when using the new Ubuntu 24 distribution family. [<a href="https://youtrack.jetbrains.com/issue/IJPL-59368/">IJPL-59368</a>, <a href="https://youtrack.jetbrains.com/issue/IJPL-59369/">IJPL-59369</a>]</li> 
 <li>Erroneous syntax highlighting no longer occurs when sticky lines are enabled. [<a href="https://youtrack.jetbrains.com/issue/IJPL-26873/">IJPL-26873</a>]</li> 
 <li>The <em>Synchronize Selected</em> functionality once again works as expected for directory comparisons. [<a href="https://youtrack.jetbrains.com/issue/IJPL-99511">IJPL-99511</a>]</li> 
 <li>Font and letter spacing are now properly displayed in the <em>Terminal</em> tool window when the <em>Use color scheme font instead of the default</em> option is enabled. [<a href="https://youtrack.jetbrains.com/issue/IJPL-36999/">IJPL-36999</a>]</li> 
 <li>The IDE no longer provides erroneous shellcheck update suggestions. [<a href="https://youtrack.jetbrains.com/issue/IJPL-103024/">IJPL-103024</a>]</li> 
</ul> Get more details in our 
<a href="https://blog.jetbrains.com/idea/2024/05/intellij-idea-2024-1-2/">blog post</a>.
    