### PR TITLE
Upgrading IntelliJ from 2024.1.5 to 2024.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Set GitHub release to 'pre-release' when the version is a `SNAPSHOT` version
 
 ### Changed
+- Upgrading IntelliJ from 2024.1.5 to 2024.2.1
 - Upgrading IntelliJ from 2024.1.4 to 2024.1.5
 - Upgrading IntelliJ from 2024.1.3 to 2024.1.4
 - Upgrading IntelliJ from 2024.1.2 to 2024.1.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libraryGroup = com.chriscarini.jetbrains
 # SemVer format -> https://semver.org
-libraryVersion = 0.0.2
+libraryVersion = 0.1.0
 
 ##
 # ----- JETBRAINS PLATFORM PLUGIN SETTINGS -----
@@ -13,7 +13,7 @@ libraryVersion = 0.0.2
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2024.1.5
+platformVersion = 2024.2.1
 platformDownloadSources = true
 
 # Java language level used to compile sources and to generate the files for


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.1.5 to 2024.2.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662153/IntelliJ-IDEA-2024.2.1-242.21829.142-build-Release-Notes

# What's New?
<p> IntelliJ IDEA 2024.2.1 is out. This release adds Java 23 support and introduces a host of noteworthy fixes and improvements: </p> 
<ul> 
 <li>The IDE no longer crashes on macOS when the terminal is open. [<a href="https://youtrack.jetbrains.com/issue/IJPL-157074">IJPL-157074</a>] </li>
 <li>The IDE no longer fails to start when non-ASCII characters are present in the installation path. [<a href="https://youtrack.jetbrains.com/issue/IJPL-156417/Cannot-start-the-IDE-due-to-Error-occurred-during-initialization-of-VM-error-when-having-non-ascii-chars-in-the-installation">IJPL-156417</a>, <a href="https://youtrack.jetbrains.com/issue/IJPL-35364/The-IDE-doesnt-start-if-an-installation-directory-contain-non-Latin-characters-that-do-not-match-to-systems-ANSI-encoding">IJPL-35364</a>] </li>
 <li>The IDE now correctly recognizes java-test-fixtures as generated test sources. [<a href="https://youtrack.jetbrains.com/issue/IDEA-353172">IDEA-353172</a>] </li>
 <li>The IDE now saves projects more quickly upon closing, resolving the issue of occasional delays. [<a href="https://youtrack.jetbrains.com/issue/IJPL-148614">IJPL-148614</a>] </li> 
</ul> 
<p> Get more details in our <a href="https://blog.jetbrains.com/idea/2024/08/intellij-idea-2024-2-1/">blog post</a>. </p>
    