### PR TITLE
Upgrading IntelliJ from 2024.2 to 2024.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Set GitHub release to 'pre-release' when the version is a `SNAPSHOT` version
 
 ### Changed
+- Upgrading IntelliJ from 2024.2 to 2024.2.2
 - Upgrading IntelliJ from 2024.1.5 to 2024.2.0
 - Upgrading IntelliJ from 2024.1.4 to 2024.1.5
 - Upgrading IntelliJ from 2024.1.3 to 2024.1.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libraryGroup = com.chriscarini.jetbrains
 # SemVer format -> https://semver.org
-libraryVersion = 0.1.0
+libraryVersion = 0.1.1
 
 ##
 # ----- JETBRAINS PLATFORM PLUGIN SETTINGS -----
@@ -13,7 +13,7 @@ libraryVersion = 0.1.0
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2024.2
+platformVersion = 2024.2.2
 platformDownloadSources = true
 
 # Java language level used to compile sources and to generate the files for


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.2 to 2024.2.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662225/IntelliJ-IDEA-2024.2.2-242.22855.74-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.2.2 is out. This release brings a host of noteworthy fixes and improvements: 
<ul> 
 <li>Highlighting no longer “blinks” upon typing.</li> 
 <li>Debugging for the spring-boot:run Maven goal is once again available.</li> 
 <li>Non-Latin letters and characters are properly displayed in the Run console.</li> 
 <li>It’s again possible to save the project settings with Coverage if the Qodana plugin is enabled.</li> 
</ul> Get more details in our 
<a href="https://blog.jetbrains.com/idea/2024/09/intellij-idea-2024-2-2/">blog post</a>.
    