### PR TITLE
Upgrading IntelliJ from 2024.2.2 to 2024.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Set GitHub release to 'pre-release' when the version is a `SNAPSHOT` version
 
 ### Changed
+- Upgrading IntelliJ from 2024.2.2 to 2024.2.3
 - Upgrading IntelliJ from 2024.2 to 2024.2.2
 - Upgrading IntelliJ from 2024.1.5 to 2024.2.1
 - Upgrading IntelliJ from 2024.1.5 to 2024.2.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libraryGroup = com.chriscarini.jetbrains
 # SemVer format -> https://semver.org
-libraryVersion = 0.1.1
+libraryVersion = 0.1.2
 
 ##
 # ----- JETBRAINS PLATFORM PLUGIN SETTINGS -----
@@ -13,7 +13,7 @@ libraryVersion = 0.1.1
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2024.2.2
+platformVersion = 2024.2.3
 platformDownloadSources = true
 
 # Java language level used to compile sources and to generate the files for


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.2.2 to 2024.2.3

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662234/IntelliJ-IDEA-2024.2.3-242.23339.11-build-Release-Notes

# What's New?
<p> IntelliJ IDEA 2024.2.3 is out! This release brings a host of noteworthy fixes and improvements: </p> 
<ul> 
 <li>Remote tools, added via the <em>Tools</em> settings, are once again visible on IDE restart. [<a href="https://youtrack.jetbrains.com/issue/IJPL-161201">IJPL-161201</a>] </li>
 <li><em>JSON Schema Mappings</em> in <em>Settings</em> now load as expected. [<a href="https://youtrack.jetbrains.com/issue/IJPL-160634">IJPL-160634</a>] </li>
 <li>The IDE with the Python plugin installed once again works as expected for remote interpreter users on Windows. [<a href="https://youtrack.jetbrains.com/issue/PY-76055/IDE-crash-on-start-at-com.jetbrains.python.remote.PyRemoteSdkAdditionalData.computeFlavor">PY-76055</a>] </li>
 <li>Schema validation for Kubernetes-like files works as expected. [<a href="https://youtrack.jetbrains.com/issue/IJPL-63687">IJPL-63687</a>] </li>
 <li><em>Settings Sync</em> again works as expected. [<a href="https://youtrack.jetbrains.com/issue/IJPL-13080">IJPL-13080</a>] </li> 
</ul> 
<p> Get more details from our <a href="https://blog.jetbrains.com/idea/2024/09/intellij-idea-2024-2-3/">blog post</a>. </p>
    