### PR TITLE
Upgrading IntelliJ from 2024.2.4 to 2024.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Set GitHub release to 'pre-release' when the version is a `SNAPSHOT` version
 
 ### Changed
+- Upgrading IntelliJ from 2024.2.4 to 2024.3.0
 - Upgrading IntelliJ from 2024.2.3 to 2024.2.4
 - Upgrading IntelliJ from 2024.2.2 to 2024.2.3
 - Upgrading IntelliJ from 2024.2 to 2024.2.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libraryGroup = com.chriscarini.jetbrains
 # SemVer format -> https://semver.org
-libraryVersion = 0.1.3
+libraryVersion = 0.2.0
 
 ##
 # ----- JETBRAINS PLATFORM PLUGIN SETTINGS -----
@@ -13,7 +13,7 @@ libraryVersion = 0.1.3
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2024.2.4
+platformVersion = 2024.3
 platformDownloadSources = true
 
 # Java language level used to compile sources and to generate the files for


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.2.4 to 2024.3.0

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662289/IntelliJ-IDEA-2024.3-243.21565.193-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.3 is out, featuring the following highlights: 
<ul>
 <li><em>Logical</em> code structure view</li>
 <li>Streamlined Kubernetes application debugging</li>
 <li>Cluster-wide Kubernetes log access</li>
 <li>Stable Kotlin K2 mode</li>
</ul> Visit our <a href="https://www.jetbrains.com/idea/whatsnew">What's New page</a> or watch <a href="https://youtu.be/NDBIYcrsC84">this video</a> to learn about these and other improvements.
    