### PR TITLE
Upgrading IntelliJ from 2024.3.1.1 to 2024.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Set GitHub release to 'pre-release' when the version is a `SNAPSHOT` version
 
 ### Changed
+- Upgrading IntelliJ from 2024.3.1.1 to 2024.3.2
 - Upgrading IntelliJ from 2024.3.1 to 2024.3.1.1
 - Upgrading IntelliJ from 2024.3 to 2024.3.1
 - Upgrading IntelliJ from 2024.2.4 to 2024.3.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libraryGroup = com.chriscarini.jetbrains
 # SemVer format -> https://semver.org
-libraryVersion = 0.2.2
+libraryVersion = 0.2.3
 
 ##
 # ----- JETBRAINS PLATFORM PLUGIN SETTINGS -----
@@ -13,7 +13,7 @@ libraryVersion = 0.2.2
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2024.3.1.1
+platformVersion = 2024.3.2
 platformDownloadSources = true
 
 # Java language level used to compile sources and to generate the files for


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.3.1.1 to 2024.3.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662349/IntelliJ-IDEA-2024.3.2-243.23654.117-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.3.2 is out! This release includes the following improvements: 
<ul>
 <li>Using certain third-party plugins no longer causes the font settings to reset to default. [<a href="https://youtrack.jetbrains.com/issue/IJPL-157487">IJPL-157487</a>]</li>
 <li>It's again possible to compile Java 7 projects with Javac version 7. [<a href="https://youtrack.jetbrains.com/issue/IDEA-361854">IDEA-361854</a>]</li>
 <li>JPA Buddy's <em>New Association Attribute</em> dialog option for @OneToMany once again works as expected. [<a href="https://youtrack.jetbrains.com/issue/IDEA-359970">IDEA-359970</a>]</li>
</ul> Get more details from our <a href="https://blog.jetbrains.com/idea/2025/01/intellij-idea-2024-3-2/">blog post</a>.
    