### PR TITLE
Upgrading IntelliJ from 2024.3.2 to 2024.3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Set GitHub release to 'pre-release' when the version is a `SNAPSHOT` version
 
 ### Changed
+- Upgrading IntelliJ from 2024.3.2 to 2024.3.2.1
 - Upgrading IntelliJ from 2024.3.1.1 to 2024.3.2
 - Upgrading IntelliJ from 2024.3.1 to 2024.3.1.1
 - Upgrading IntelliJ from 2024.3 to 2024.3.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libraryGroup = com.chriscarini.jetbrains
 # SemVer format -> https://semver.org
-libraryVersion = 0.2.3
+libraryVersion = 0.2.4
 
 ##
 # ----- JETBRAINS PLATFORM PLUGIN SETTINGS -----
@@ -13,7 +13,7 @@ libraryVersion = 0.2.3
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2024.3.2
+platformVersion = 2024.3.2.1
 platformDownloadSources = true
 
 # Java language level used to compile sources and to generate the files for


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.3.2 to 2024.3.2.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662352/IntelliJ-IDEA-2024.3.2.1-243.23654.153-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.3.2.1 is out with the following hotfix: 
<ul>
 <li>The <em>Code Completion </em>popup no longer erroneously displays duplicated code suggestion options. [<a href="https://youtrack.jetbrains.com/issue/WEB-71082">WEB-71082</a>]</li>
</ul> For more details, please refer to the release notes.
    