### PR TITLE
Upgrading IntelliJ from 2024.3.2.2 to 2024.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Set GitHub release to 'pre-release' when the version is a `SNAPSHOT` version
 
 ### Changed
+- Upgrading IntelliJ from 2024.3.2.2 to 2024.3.3
 - Upgrading IntelliJ from 2024.3.2.1 to 2024.3.2.2
 - Upgrading IntelliJ from 2024.3.2 to 2024.3.2.1
 - Upgrading IntelliJ from 2024.3.1.1 to 2024.3.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libraryGroup = com.chriscarini.jetbrains
 # SemVer format -> https://semver.org
-libraryVersion = 0.2.5
+libraryVersion = 0.2.6
 
 ##
 # ----- JETBRAINS PLATFORM PLUGIN SETTINGS -----
@@ -13,7 +13,7 @@ libraryVersion = 0.2.5
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2024.3.2.2
+platformVersion = 2024.3.3
 platformDownloadSources = true
 
 # Java language level used to compile sources and to generate the files for


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.3.2.2 to 2024.3.3

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662361/IntelliJ-IDEA-2024.3.3-243.24978.46-build-Release-Notes

# What's New?
<p>IntelliJ IDEA 2024.3.3 is out with the following improvements:</p>
<ul>
 <li>The <em>Reload All Maven Projects</em> action now correctly syncs dependencies. [<a href="https://youtrack.jetbrains.com/issue/IDEA-358024">IDEA-358024</a>]</li>
 <li>Screen reader detection now works on the first startup on Windows. [<a href="https://youtrack.jetbrains.com/issue/IJPL-173992/Screen-reader-detection-on-the-first-start-up-stopped-working-on-Windows">IJPL-173992</a>]</li>
 <li>Custom toolbar icons for external tools are now properly displayed after an IDE restart. [<a href="https://youtrack.jetbrains.com/issue/IJPL-172075/Custom-toolbar-icons-for-External-tools-is-not-shown-after-IDE-restart">IJPL-172075</a>]</li>
</ul>
<p>Get more details in our <a href="https://blog.jetbrains.com/idea/2025/02/intellij-idea-2024-3-3/">blog post</a>.</p>
    