### PR TITLE
Upgrading IntelliJ from 2024.3.3 to 2024.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Set GitHub release to 'pre-release' when the version is a `SNAPSHOT` version
 
 ### Changed
+- Upgrading IntelliJ from 2024.3.3 to 2024.3.4
 - Upgrading IntelliJ from 2024.3.2.2 to 2024.3.3
 - Upgrading IntelliJ from 2024.3.2.1 to 2024.3.2.2
 - Upgrading IntelliJ from 2024.3.2 to 2024.3.2.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libraryGroup = com.chriscarini.jetbrains
 # SemVer format -> https://semver.org
-libraryVersion = 0.2.6
+libraryVersion = 0.2.7
 
 ##
 # ----- JETBRAINS PLATFORM PLUGIN SETTINGS -----
@@ -13,7 +13,7 @@ libraryVersion = 0.2.6
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2024.3.3
+platformVersion = 2024.3.4
 platformDownloadSources = true
 
 # Java language level used to compile sources and to generate the files for


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.3.3 to 2024.3.4

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662385/IntelliJ-IDEA-2024.3.4-243.25659.39-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.3.4 is out with the following improvements: 
<ul>
 <li>The IDE no longer incorrectly reports missing required keys in gitlab-ci.yml. [<a href="https://youtrack.jetbrains.com/issue/IJPL-171698">IJPL-171698</a>]</li>
 <li>The IDE no longer adds unnecessary spaces around slashes when copying text from the quick documentation. [<a href="https://youtrack.jetbrains.com/issue/IJPL-149061">IJPL-149061</a>]</li>
 <li>Plugin updates are once again detected and processed correctly. [<a href="https://youtrack.jetbrains.com/issue/IJPL-175450">IJPL-175450</a>]</li>
 <li>AWS providers in Terraform are now properly recognized, with correct code completion. [<a href="https://youtrack.jetbrains.com/issue/IJPL-164351">IJPL-164351</a>]</li>
 <li>Several issues related to the Kafka plugin have been resolved. [<a href="https://youtrack.jetbrains.com/issue/IJPL-176005">IJPL-176005</a>, <a href="https://youtrack.jetbrains.com/issue/IJPL-159726">IJPL-159726</a>, <a href="https://youtrack.jetbrains.com/issue/IJPL-172466">IJPL-172466</a>, <a href="https://youtrack.jetbrains.com/issue/IJPL-172433">IJPL-172433</a>]</li>
</ul> Get more details in our <a href="https://blog.jetbrains.com/idea/2025/02/intellij-idea-2024-3-4/">blog post</a>.
    