### PR TITLE
Upgrading IntelliJ from 2024.3.5 to 2025.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Set GitHub release to 'pre-release' when the version is a `SNAPSHOT` version
 
 ### Changed
+- Upgrading IntelliJ from 2024.3.5 to 2025.1
 - Upgrading IntelliJ from 2024.3.4 to 2024.3.5
 - Upgrading IntelliJ from 2024.3.3 to 2024.3.4
 - Upgrading IntelliJ from 2024.3.2.2 to 2024.3.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libraryGroup = com.chriscarini.jetbrains
 # SemVer format -> https://semver.org
-libraryVersion = 0.2.8
+libraryVersion = 1.0.0
 
 ##
 # ----- JETBRAINS PLATFORM PLUGIN SETTINGS -----
@@ -13,7 +13,7 @@ libraryVersion = 0.2.8
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2024.3.5
+platformVersion = 2025.1
 platformDownloadSources = true
 
 # Java language level used to compile sources and to generate the files for


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.3.5 to 2025.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662421/IntelliJ-IDEA-2025.1-251.23774.435-build-Release-Notes

# What's New?
IntelliJ IDEA 2025.1 is out! Highlights include: 
<ul>
 <li>Java 24 support</li>
 <li>K2 mode by default</li>
 <li>Kotlin notebooks for everyone</li>
 <li>Control over watch evaluators</li>
</ul> Visit our <a href="https://www.jetbrains.com/idea/whatsnew">What's New page</a> to learn about these and other improvements.
    