### PR TITLE
Upgrading IntelliJ from 2025.1 to 2025.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Set GitHub release to 'pre-release' when the version is a `SNAPSHOT` version
 
 ### Changed
+- Upgrading IntelliJ from 2025.1 to 2025.1.1
 - Upgrading IntelliJ from 2024.3.5 to 2025.1
 - Upgrading IntelliJ from 2024.3.4 to 2024.3.5
 - Upgrading IntelliJ from 2024.3.3 to 2024.3.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ libraryVersion = 1.0.0
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2025.1
+platformVersion = 2025.1.1
 platformDownloadSources = true
 
 # Java language level used to compile sources and to generate the files for


### PR DESCRIPTION

# Upgrading IntelliJ from 2025.1 to 2025.1.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662429/IntelliJ-IDEA-2025.1.1-251.25410.109-build-Release-Notes

# What's New?
IntelliJ IDEA 2025.1.1 is out! Here are the most notable updates: 
<ul>
 <li>Setting backup and synchronization via <i>Backup and Sync</i> now works as expected upon authorization with JetBrains Account. [<a href="https://youtrack.jetbrains.com/issue/IJPL-183565">IJPL-183565</a>]</li>
 <li>Debugging tests when using Gradle 7.x.x no longer fails. [<a href="https://youtrack.jetbrains.com/issue/IDEA-369597/">IDEA-369597</a>]</li>
 <li>The IDE again correctly imports Maven projects that use several --add-exports arguments. [<a href="https://youtrack.jetbrains.com/issue/IDEA-371005/Maven-Invalid-compiler-parameters-generated-for-multiple-add-exports-in-pom.xml-compilerArgs">IDEA-371005</a>]</li>
 <li>The <i>Paths</i> filter in the <i>Git</i> tool window again works as expected, filtering branches according to the selected repository. [<a href="https://youtrack.jetbrains.com/issue/IJPL-182203/251-Beta-Branches-pane-not-filtered-by-paths-filter-in-the-log-pane">IJPL-182203</a>]</li>
</ul> Get more details from our <a href="https://blog.jetbrains.com/idea/2025/05/intellij-idea-2025-1-1/">blog post</a>.
    