### PR TITLE
Upgrading IntelliJ from 2025.1.1 to 2025.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Set GitHub release to 'pre-release' when the version is a `SNAPSHOT` version
 
 ### Changed
+- Upgrading IntelliJ from 2025.1.1 to 2025.1.2
 - Upgrading IntelliJ from 2025.1 to 2025.1.1
 - Upgrading IntelliJ from 2024.3.5 to 2025.1
 - Upgrading IntelliJ from 2024.3.4 to 2024.3.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libraryGroup = com.chriscarini.jetbrains
 # SemVer format -> https://semver.org
-libraryVersion = 1.0.0
+libraryVersion = 1.0.1
 
 ##
 # ----- JETBRAINS PLATFORM PLUGIN SETTINGS -----
@@ -13,7 +13,7 @@ libraryVersion = 1.0.0
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2025.1.1
+platformVersion = 2025.1.2
 platformDownloadSources = true
 
 # Java language level used to compile sources and to generate the files for


### PR DESCRIPTION

# Upgrading IntelliJ from 2025.1.1 to 2025.1.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662452/IntelliJ-IDEA-2025.1.2-251.26094.121-build-Release-Notes

# What's New?
<p>IntelliJ IDEA 2025.1.2 is out with the following improvements:</p>
<ul>
 <li>The IDE no longer fails to start if a plugin defines an action with unresolved message bundle keys, and it now provides a report identifying the problematic plugin. [<a href="https://youtrack.jetbrains.com/issue/IJPL-185981">IJPL-185981</a>]</li>
 <li>The IDE no longer produces the false positive <em>"Package is declared in module which is not in the module graph"</em> warning. [<a href="https://youtrack.jetbrains.com/issue/IDEA-371051">IDEA-371051</a>]</li>
 <li>The IDE once again correctly takes compilerArgs from <em>pom.xml </em>into account when building Maven projects. [<a href="https://youtrack.jetbrains.com/issue/IDEA-371747">IDEA-371747</a>]</li>
 <li>Font size rescaling for the Quick Documentation popup works as expected. [<a href="https://youtrack.jetbrains.com/issue/IJPL-184559/Cannot-adjust-font-size-of-quick-documentation-pop-up-windows">IJPL-184559</a>]</li>
 <li>Inspections in Terraform can now be suppressed again. [<a href="https://youtrack.jetbrains.com/issue/IJPL-149116/Suppress-inspection-dont-work-in-TerraForm-file">IJPL-149116</a>]<br></li>
</ul>
<p>Get more details from our <a href="https://blog.jetbrains.com/idea/2025/06/intellij-idea-2025-1-2/">blog post</a>.</p>
    