### PR TITLE
Upgrading IntelliJ from 2025.1.1 to 2025.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Set GitHub release to 'pre-release' when the version is a `SNAPSHOT` version
 
 ### Changed
+- Upgrading IntelliJ from 2025.1.1 to 2025.1.3
 - Upgrading IntelliJ from 2025.1 to 2025.1.1
 - Upgrading IntelliJ from 2024.3.5 to 2025.1
 - Upgrading IntelliJ from 2024.3.4 to 2024.3.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libraryGroup = com.chriscarini.jetbrains
 # SemVer format -> https://semver.org
-libraryVersion = 1.0.0
+libraryVersion = 1.0.1
 
 ##
 # ----- JETBRAINS PLATFORM PLUGIN SETTINGS -----
@@ -13,7 +13,7 @@ libraryVersion = 1.0.0
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2025.1.1
+platformVersion = 2025.1.3
 platformDownloadSources = true
 
 # Java language level used to compile sources and to generate the files for


### PR DESCRIPTION

# Upgrading IntelliJ from 2025.1.1 to 2025.1.3

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662461/IntelliJ-IDEA-2025.1.3-251.26927.53-build-Release-Notes

# What's New?
<p>IntelliJ IDEA 2025.1.3 is out with the following improvements:</p>
<ul>
 <li>The IDE no longer erroneously displays &lt;no name&gt; in the <em>Test Results</em> tree in the <em>Run</em> tool window for Dart tests. [<a href="https://youtrack.jetbrains.com/issue/IDEA-328307/Dart-tests-no-name-shown-under-Test-Results">IDEA-328307</a>]</li>
 <li>The preview panel is now available for AsyncAPI 3.0 files. [<a href="https://youtrack.jetbrains.com/issue/IJPL-63246/AsyncAPI-Preview-not-available-for-version-3.0">IJPL-63246</a>]</li>
 <li>The IDE no longer truncates postCreateCommand environment variables at equals signs in the build process output. [<a href="https://youtrack.jetbrains.com/issue/IJPL-188006/PostCreateCommand-environment-variables-are-truncated-at-equals-signs">IJPL-188006</a>]</li>
</ul>
<ul>
 <li>The IDE no longer misses OS-specific plugins in Aarch64 distributions, including those required for WSL support in the Python interpreter. [<a href="https://youtrack.jetbrains.com/issue/IJPL-189778/OS-specific-plugins-could-be-missing-in-Aarch64-distributions">IJPL-189778</a>]</li>
</ul>
<p>Get more details from our <a href="https://blog.jetbrains.com/idea/2025/06/intellij-idea-2025-1-3/">blog post</a>.</p>
    