### PR TITLE
Upgrading IntelliJ from 2025.2.1 to 2025.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Set GitHub release to 'pre-release' when the version is a `SNAPSHOT` version
 
 ### Changed
+- Upgrading IntelliJ from 2025.2.1 to 2025.2.2
 - Upgrading IntelliJ from 2025.2 to 2025.2.1
 - Upgrading IntelliJ from 2025.1.4.1 to 2025.2
 - Upgrading IntelliJ from 2025.1.3 to 2025.1.4.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libraryGroup = com.chriscarini.jetbrains
 # SemVer format -> https://semver.org
-libraryVersion = 1.1.0
+libraryVersion = 1.1.1
 
 ##
 # ----- JETBRAINS PLATFORM PLUGIN SETTINGS -----
@@ -13,7 +13,7 @@ libraryVersion = 1.1.0
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2025.2.1
+platformVersion = 2025.2.2
 platformDownloadSources = true
 
 # Java language level used to compile sources and to generate the files for


### PR DESCRIPTION

# Upgrading IntelliJ from 2025.2.1 to 2025.2.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662504/IntelliJ-IDEA-2025.2.2-252.26199.169-build-Release-Notes

# What's New?
<p>IntelliJ IDEA 2025.2.2 is available! Here are the most notable updates:</p>
<ul>
 <li>The <em>Run Maven Build</em> icon is once again available in the Maven panel toolbar. [<a href="https://youtrack.jetbrains.com/issue/IDEA-376149/">IDEA-376149</a>]</li>
 <li>Remote SSH external tools now work as expected. [<a href="https://youtrack.jetbrains.com/issue/IJPL-200406/">IJPL-200406</a>]</li>
 <li>The IDE again correctly parses environment variables with semicolon values pasted in the <em>Run/Debug</em> dialog. [<a href="https://youtrack.jetbrains.com/issue/IJPL-200754/">IJPL-200754</a>]</li>
 <li>The IDE now properly handles MAVEN_OPTS environment variables. [<a href="https://youtrack.jetbrains.com/issue/IDEA-368366/">IDEA-368366</a>]</li>
 <li>On Windows, the <em>Find in Files</em> dialog again works as expected, closes correctly, and no longer shows a persistent green area. [<a href="https://youtrack.jetbrains.com/issue/IJPL-162798/">IJPL-162798</a>]</li>
</ul>
<p>Get more details in our <a href="https://blog.jetbrains.com/idea/2025/09/intellij-idea-2025-2-2/">blog post</a>.</p>
    