### PR TITLE
Upgrading IntelliJ from 2025.2.2 to 2025.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Set GitHub release to 'pre-release' when the version is a `SNAPSHOT` version
 
 ### Changed
+- Upgrading IntelliJ from 2025.2.2 to 2025.2.3
 - Upgrading IntelliJ from 2025.2.1 to 2025.2.2
 - Upgrading IntelliJ from 2025.2 to 2025.2.1
 - Upgrading IntelliJ from 2025.1.4.1 to 2025.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libraryGroup = com.chriscarini.jetbrains
 # SemVer format -> https://semver.org
-libraryVersion = 1.1.1
+libraryVersion = 1.1.2
 
 ##
 # ----- JETBRAINS PLATFORM PLUGIN SETTINGS -----
@@ -13,7 +13,7 @@ libraryVersion = 1.1.1
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2025.2.2
+platformVersion = 2025.2.3
 platformDownloadSources = true
 
 # Java language level used to compile sources and to generate the files for


### PR DESCRIPTION

# Upgrading IntelliJ from 2025.2.2 to 2025.2.3

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662511/IntelliJ-IDEA-2025.2.3-252.26830.84-build-Release-Notes

# What's New?
IntelliJ IDEA 2025.2.3 is out! This release includes the following improvements: 
<ul>
 <li>Jira Task Server integration now works as before when fetching tasks. [<a href="https://youtrack.jetbrains.com/issue/IJPL-208931">IJPL-208931</a>]</li>
 <li>Breakpoints now work as expected in the Services view when the ClassicUI plugin is enabled. [<a href="https://youtrack.jetbrains.com/issue/IDEA-378292">IDEA-378292</a>]</li>
 <li>It's once again possible to open multiple files from the <i>Find Usages</i> dialog. [<a href="https://youtrack.jetbrains.com/issue/IJPL-201422">IJPL-201422</a>]</li>
</ul> Get more details from our <a href="https://blog.jetbrains.com/idea/2025/10/intellij-idea-2025-2-3/">blog post</a>.
    