### PR TITLE
Upgrading IntelliJ from 2026.1 to 2026.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Set GitHub release to 'pre-release' when the version is a `SNAPSHOT` version
 
 ### Changed
+- Upgrading IntelliJ from 2026.1 to 2026.1.1
 - Upgrading IntelliJ from 2025.3.4 to 2026.1
 - Upgrading IntelliJ from 2025.3.3 to 2025.3.4
 - Upgrading IntelliJ from 2025.3.2 to 2025.3.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libraryGroup = com.chriscarini.jetbrains
 # SemVer format -> https://semver.org
-libraryVersion = 2.0.0
+libraryVersion = 2.0.1
 
 ##
 # ----- JETBRAINS PLATFORM PLUGIN SETTINGS -----
@@ -13,7 +13,7 @@ libraryVersion = 2.0.0
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2026.1
+platformVersion = 2026.1.1
 platformDownloadSources = true
 
 # Java language level used to compile sources and to generate the files for


### PR DESCRIPTION

# Upgrading IntelliJ from 2026.1 to 2026.1.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662664

# What's New?
<p>IntelliJ IDEA 2026.1.1 is out with the following improvements:</p>
<ul>
 <li>It's once again possible to set up a WSL Python SDK. [<a href="https://youtrack.jetbrains.com/issue/IJPL-240728/Unable-to-add-WSL-Python-SDK">IJPL-240728</a>]</li>
 <li>Emmet in remote development now works as expected. [<a href="https://youtrack.jetbrains.com/issue/IJPL-168255">IJPL-168255</a>]</li>
 <li>Gradle sync no longer fails due to a class cast error involving <code>InternalIdeaModule</code> and <code>org.gradle.tooling.model.ProjectModel</code>. [<a href="https://youtrack.jetbrains.com/issue/IDEA-386409/Gradle-sync-fails-with-InternalIdeaModule-cannot-be-cast-to-class-org.gradle.tooling.model.ProjectModel">IDEA-386409</a>]</li>
 <li>The IDE now correctly connects to the WildFly admin process after server startup, restoring deployment and the <em>Open browser after launch</em> option. [<a href="https://youtrack.jetbrains.com/issue/IDEA-387483">IDEA-387483</a>]</li>
</ul>
<p>Get more details in our <a href="https://blog.jetbrains.com/idea/2026/04/intellij-idea-2026-1-1/">blog post</a>.</p>
    