### PR TITLE
Upgrading IntelliJ from 2026.1.3 to 2026.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Set GitHub release to 'pre-release' when the version is a `SNAPSHOT` version
 
 ### Changed
+- Upgrading IntelliJ from 2026.1.3 to 2026.1.4
 - Bump the JDK used to build/test from 17 to 21 (required by IntelliJ Platform 2025.3+)
 - Migrate the IntelliJ Platform Gradle Plugin from `org.jetbrains.intellij` `1.17.4` to `org.jetbrains.intellij.platform` (module) `2.16.0` (compatible with Gradle 9)
 - Upgrading IntelliJ from 2026.1.2 to 2026.1.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 libraryGroup = com.chriscarini.jetbrains
 # SemVer format -> https://semver.org
-libraryVersion = 2.0.3
+libraryVersion = 2.0.4
 
 ##
 # ----- JETBRAINS PLATFORM PLUGIN SETTINGS -----
@@ -13,7 +13,7 @@ libraryVersion = 2.0.3
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2026.1.3
+platformVersion = 2026.1.4
 
 # Java language level used to compile sources and to generate the files for
 # - Java 11 is required since 2020.3


### PR DESCRIPTION

# Upgrading IntelliJ from 2026.1.3 to 2026.1.4

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662699

# What's New?
<p>IntelliJ IDEA 2026.1.4 is out with the following improvements:</p>
<ul>
 <li>The active Git branch now updates correctly. [<a href="https://youtrack.jetbrains.com/issue/IJPL-240184/Git-update-is-disabled-on-the-active-branch">IJPL-240184</a>]</li>
 <li>Fixed an issue where using <code>pull_policy</code> in Docker Compose files prevented the PHP interpreter from being created. [<a href="https://youtrack.jetbrains.com/issue/IJPL-189121/">IJPL-189121</a>]</li>
 <li>The IDE no longer erroneously marks successful Gradle syncs as failed when running Gradle 9.5.0 on WSL. [<a href="https://youtrack.jetbrains.com/issue/IDEA-388949/Gradle-Successful-sync-shown-as-failed-since-Gradle-9.5.0-on-WSL">IDEA-388949</a>]</li>
 <li>Fixed an error that caused Dev Container connections to fail with an <em>Unknown Docker endpoint schema</em> message. [<a href="https://youtrack.jetbrains.com/issue/IJPL-240184/Git-update-is-disabled-on-the-active-branch">IJPL-240184</a>]</li>
</ul>
<p>Get more details in our <a href="https://blog.jetbrains.com/idea/2026/06/intellij-idea-2026-1-4/">blog post</a>.</p>
    